### PR TITLE
Enable clientid to be passed as HTTP get_user parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ then an error is returned and the client is disconnected.
 
 | URI-Param         | username | password | clientid | topic | acc |
 | ----------------- | -------- | -------- | -------- | :---: | :-: |
-| http_getuser_uri  |   Y      |   Y      |   N      |   N   |  N  |
+| http_getuser_uri  |   Y      |   Y      |   Y      |   N   |  N  |
 | http_superuser_uri|   Y      |   N      |   N      |   N   |  N  |
 | http_aclcheck_uri |   Y      |   N      |   Y      |   Y   |  Y  |
 

--- a/src/auth-plug.c
+++ b/src/auth-plug.c
@@ -523,12 +523,12 @@ int mosquitto_auth_unpwd_check(void *userdata, const char *username, const char 
 		free(e->username);
 		free(e->clientid);
 		e->username = strdup(username);
-		e->clientid = strdup("client id not available");
+		e->clientid = strdup(mosquitto_client_id(client));
 	} else {
 		e = (struct cliententry *)malloc(sizeof(struct cliententry));
 		e->key = (void *)client;
 		e->username = strdup(username);
-		e->clientid = strdup("client id not available");
+		e->clientid = strdup(mosquitto_client_id(client));
 		HASH_ADD(hh, ud->clients, key, sizeof(void *), e);
 	}
 #endif

--- a/src/be-http.c
+++ b/src/be-http.c
@@ -318,7 +318,7 @@ int be_http_getuser(void *handle, const char *username, const char *password, ch
 
 	while (re == BACKEND_ERROR && try <= conf->retry_count) {
 		try++;
-		re = http_post(handle, conf->getuser_uri, NULL, username, password, NULL, -1, METHOD_GETUSER);
+		re = http_post(handle, conf->getuser_uri, clientid, username, password, NULL, -1, METHOD_GETUSER);
 	}
 	return re;
 };


### PR DESCRIPTION
In some cases, you might perform finer ACL and Authentication checks based on both username and clientid. 
The current HTTP backend does not support clientid parameter. 

This PR adds the capability to pass the clientid parameter to the HTTP backend authenticator.